### PR TITLE
FIX: npm run lint

### DIFF
--- a/lib/AbstractPlane.js
+++ b/lib/AbstractPlane.js
@@ -359,7 +359,7 @@ p.transformBy = function (itr, plane) {
 
   // Convert ITransform to Transform.
   // If already Transform, leave as it is.
-  if (itr.hasOwnProperty('_tr')) {
+  if (Object.prototype.hasOwnProperty.call(itr, '_tr')) {
     itr = itr.to(plane)
   }
 

--- a/lib/SpaceView/index.js
+++ b/lib/SpaceView/index.js
@@ -82,8 +82,10 @@ p.fitScale = function (ipath) {
   // dimensions with to fit.
   //
   if (!this.isMounted()) {
-    throw new Error('View is not yet mounted and thus has no proper size ' +
-      'for fitting. Call mount() before fitScale().')
+    throw new Error(
+      'View is not yet mounted and thus has no proper size ' +
+        'for fitting. Call mount() before fitScale().'
+    )
   }
 
   return AbstractRectangle.prototype.fitScale.call(this, ipath)
@@ -118,7 +120,7 @@ p.getSpaceItemByElementId = function (id) {
   // Return null if no node for such id.
   var el = document.getElementById(id)
 
-  if (el && el.hasOwnProperty(DOM_SPACENODE_PROPERTY)) {
+  if (el && Object.prototype.hasOwnProperty.call(el, DOM_SPACENODE_PROPERTY)) {
     return el[DOM_SPACENODE_PROPERTY]
   }
 
@@ -343,7 +345,7 @@ p._renderElementFor = function (abstractNode) {
   }
 
   // Prevent bugs that double-render elements
-  if (this._elements.hasOwnProperty(n.id)) {
+  if (Object.prototype.hasOwnProperty.call(this._elements, n.id)) {
     throw new Error('An element should not be added twice to the same view.')
   }
 

--- a/lib/Touchable/MouseConverter.js
+++ b/lib/Touchable/MouseConverter.js
@@ -1,4 +1,3 @@
-
 var startMouseConversion = function (container) {
   // Re-emit mouse events as custom touch-like events, "rats".
   // The mouse events that reach the given HTMLElement are converted so
@@ -140,7 +139,7 @@ var MouseConverter = function () {
 
 MouseConverter.prototype.start = function (view) {
   // If already running
-  if (this.numRunning.hasOwnProperty(view.id)) {
+  if (Object.prototype.hasOwnProperty.call(this.numRunning, view.id)) {
     this.numRunning[view.id] += 1
     return // only increase the counter
   }
@@ -155,7 +154,7 @@ MouseConverter.prototype.start = function (view) {
 MouseConverter.prototype.stop = function (view) {
   // Stops conversion when stop() is called as many
   // times as start for the view.
-  if (this.numRunning.hasOwnProperty(view.id)) {
+  if (Object.prototype.hasOwnProperty.call(this.numRunning, view.id)) {
     this.numRunning[view.id] -= 1
   } else {
     throw new Error('Stop called before start.')

--- a/lib/Touchable/Recognizer.js
+++ b/lib/Touchable/Recognizer.js
@@ -19,6 +19,10 @@ var IVector = require('../geom/IVector')
 var Vector = require('../geom/Vector')
 var nudged = require('nudged')
 
+var hasProp = function (obj, prop) {
+  return obj && Object.prototype.hasOwnProperty.call(obj, prop)
+}
+
 var toRawPivot = function (mode, plane) {
   // The pivot needs to be converted to [x, y]
   // on plane's coordinate plane.
@@ -63,7 +67,7 @@ var rebase = function (pointers, sourcePlane, targetPlane) {
   var targetToSpace = targetPlane.getGlobalTransform()
   var sourceToTarget = targetToSpace.inverse().multiplyRight(sourceToSpace)
   for (k in pointers) {
-    if (Object.prototype.hasOwnProperty.call(pointers, k)) {
+    if (hasProp(pointers, k)) {
       result[k] = sourceToTarget.transform(pointers[k])
     }
   }
@@ -75,7 +79,7 @@ var rebaseToSpace = function (pointers, sourcePlane) {
   var result = {}
   var sourceToSpace = sourcePlane.getGlobalTransform()
   for (k in pointers) {
-    if (Object.prototype.hasOwnProperty.call(pointers, k)) {
+    if (hasProp(pointers, k)) {
       result[k] = sourceToSpace.transform(pointers[k])
     }
   }
@@ -88,7 +92,7 @@ var toTapPoints = function (ps) {
   var k
   var result = []
   for (k in ps) {
-    if (Object.prototype.hasOwnProperty.call(ps, k)) {
+    if (hasProp(ps, k)) {
       result.push(new IVector(new Vector(ps[k][0], ps[k][1])))
     }
   }
@@ -102,7 +106,7 @@ var multiplyLeft = function (pointers, transform) {
   var k
   var result = {}
   for (k in pointers) {
-    if (Object.prototype.hasOwnProperty.call(pointers, k)) {
+    if (hasProp(pointers, k)) {
       result[k] = transform.transform(pointers[k])
     }
   }
@@ -178,10 +182,7 @@ var Recognizer = function (manager) {
     // Set intersection. Do not use removed or appeared pointers
     // in transformation estimation.
     for (k in pointersOnItem) {
-      if (
-        Object.prototype.hasOwnProperty.call(pointersOnItem, k) &&
-        Object.prototype.hasOwnProperty.call(nextPointersOnItem, k)
-      ) {
+      if (hasProp(pointersOnItem, k) && hasProp(nextPointersOnItem, k)) {
         domain.push(pointersOnItem[k])
         range.push(nextPointersOnItem[k])
       }
@@ -191,10 +192,7 @@ var Recognizer = function (manager) {
     // provide them in the tap event.
     var viewToSpace = view.getGlobalTransform()
     for (k in nextPointersOnItem) {
-      if (
-        Object.prototype.hasOwnProperty.call(nextPointersOnItem, k) &&
-        !Object.prototype.hasOwnProperty.call(touchPointLog, k)
-      ) {
+      if (hasProp(nextPointersOnItem, k) && !hasProp(touchPointLog, k)) {
         // New pointer
         touchPointLog[k] = viewToSpace.transform(nextPointersOnItem[k])
       }
@@ -214,10 +212,7 @@ var Recognizer = function (manager) {
     // of the space, but only the screen pixels.
     n = domain.length
     for (k in prevPointers) {
-      if (
-        Object.prototype.hasOwnProperty.call(prevPointers, k) &&
-        Object.prototype.hasOwnProperty.call(nextPointers, k)
-      ) {
+      if (hasProp(prevPointers, k) && hasProp(nextPointers, k)) {
         totalTravel += Math.abs(prevPointers[k][0] - nextPointers[k][0]) / n
         totalTravel += Math.abs(prevPointers[k][1] - nextPointers[k][1]) / n
       }

--- a/lib/Touchable/Recognizer.js
+++ b/lib/Touchable/Recognizer.js
@@ -29,7 +29,10 @@ var toRawPivot = function (mode, plane) {
 
   // Use middle of plane as a default pivot if translation not allowed.
   if (mode.translate === false) {
-    return plane.atMid().to(plane).toArray()
+    return plane
+      .atMid()
+      .to(plane)
+      .toArray()
   }
 
   // Return undefined so that when rawPivot is given as a parameter
@@ -60,7 +63,7 @@ var rebase = function (pointers, sourcePlane, targetPlane) {
   var targetToSpace = targetPlane.getGlobalTransform()
   var sourceToTarget = targetToSpace.inverse().multiplyRight(sourceToSpace)
   for (k in pointers) {
-    if (pointers.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(pointers, k)) {
       result[k] = sourceToTarget.transform(pointers[k])
     }
   }
@@ -72,7 +75,7 @@ var rebaseToSpace = function (pointers, sourcePlane) {
   var result = {}
   var sourceToSpace = sourcePlane.getGlobalTransform()
   for (k in pointers) {
-    if (pointers.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(pointers, k)) {
       result[k] = sourceToSpace.transform(pointers[k])
     }
   }
@@ -85,7 +88,7 @@ var toTapPoints = function (ps) {
   var k
   var result = []
   for (k in ps) {
-    if (ps.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(ps, k)) {
       result.push(new IVector(new Vector(ps[k][0], ps[k][1])))
     }
   }
@@ -99,7 +102,7 @@ var multiplyLeft = function (pointers, transform) {
   var k
   var result = {}
   for (k in pointers) {
-    if (pointers.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(pointers, k)) {
       result[k] = transform.transform(pointers[k])
     }
   }
@@ -175,8 +178,10 @@ var Recognizer = function (manager) {
     // Set intersection. Do not use removed or appeared pointers
     // in transformation estimation.
     for (k in pointersOnItem) {
-      if (pointersOnItem.hasOwnProperty(k) &&
-          nextPointersOnItem.hasOwnProperty(k)) {
+      if (
+        Object.prototype.hasOwnProperty.call(pointersOnItem, k) &&
+        Object.prototype.hasOwnProperty.call(nextPointersOnItem, k)
+      ) {
         domain.push(pointersOnItem[k])
         range.push(nextPointersOnItem[k])
       }
@@ -186,8 +191,10 @@ var Recognizer = function (manager) {
     // provide them in the tap event.
     var viewToSpace = view.getGlobalTransform()
     for (k in nextPointersOnItem) {
-      if (nextPointersOnItem.hasOwnProperty(k) &&
-          !touchPointLog.hasOwnProperty(k)) {
+      if (
+        Object.prototype.hasOwnProperty.call(nextPointersOnItem, k) &&
+        !Object.prototype.hasOwnProperty.call(touchPointLog, k)
+      ) {
         // New pointer
         touchPointLog[k] = viewToSpace.transform(nextPointersOnItem[k])
       }
@@ -207,7 +214,10 @@ var Recognizer = function (manager) {
     // of the space, but only the screen pixels.
     n = domain.length
     for (k in prevPointers) {
-      if (prevPointers.hasOwnProperty(k) && nextPointers.hasOwnProperty(k)) {
+      if (
+        Object.prototype.hasOwnProperty.call(prevPointers, k) &&
+        Object.prototype.hasOwnProperty.call(nextPointers, k)
+      ) {
         totalTravel += Math.abs(prevPointers[k][0] - nextPointers[k][0]) / n
         totalTravel += Math.abs(prevPointers[k][1] - nextPointers[k][1]) / n
       }
@@ -287,11 +297,15 @@ var Recognizer = function (manager) {
   }
 
   // Handlers defined, construct sensor
-  this.sensor = new Sensor(this.man.element, {
-    start: onStart,
-    move: onMove,
-    end: onEnd
-  }, this.man.mode)
+  this.sensor = new Sensor(
+    this.man.element,
+    {
+      start: onStart,
+      move: onMove,
+      end: onEnd
+    },
+    this.man.mode
+  )
 }
 
 Recognizer.prototype.update = function (mode) {

--- a/lib/Touchable/Sensor.js
+++ b/lib/Touchable/Sensor.js
@@ -95,7 +95,7 @@ module.exports = function Sensor (element, handlers, opts) {
         // For example. ev.changedTouches contains _all_ changed touches
         // in Chrome on Android regardless of their target. See issue #87
         id = cts[i].identifier
-        if (nextPointers.hasOwnProperty(id)) {
+        if (Object.prototype.hasOwnProperty.call(nextPointers, id)) {
           nextPointers[id] = [cts[i].pageX, cts[i].pageY]
         }
       }
@@ -152,7 +152,7 @@ module.exports = function Sensor (element, handlers, opts) {
         _mouseDown = true
 
         nextPointers = utils.clone(_currPointers) // See [2]
-        nextPointers['mouse'] = [ev.pageX, ev.pageY]
+        nextPointers.mouse = [ev.pageX, ev.pageY]
 
         if (!_started) {
           _started = true
@@ -173,7 +173,7 @@ module.exports = function Sensor (element, handlers, opts) {
       }
 
       nextPointers = utils.clone(_currPointers)
-      nextPointers['mouse'] = [ev.pageX, ev.pageY]
+      nextPointers.mouse = [ev.pageX, ev.pageY]
 
       _handlers.move(_currPointers, nextPointers)
 
@@ -192,7 +192,7 @@ module.exports = function Sensor (element, handlers, opts) {
       }
 
       nextPointers = utils.clone(_currPointers)
-      delete nextPointers['mouse']
+      delete nextPointers.mouse
 
       // See [1]
       if (utils.cardinality(nextPointers) < 1) {
@@ -232,7 +232,7 @@ module.exports = function Sensor (element, handlers, opts) {
   this.destroy = function () {
     // Remove all listeners we made
     for (var k in _listeners) {
-      if (_listeners.hasOwnProperty(k)) {
+      if (Object.prototype.hasOwnProperty.call(_listeners, k)) {
         _el.removeEventListener(k, _listeners[k])
       }
     }

--- a/lib/Touchable/utils.js
+++ b/lib/Touchable/utils.js
@@ -1,3 +1,7 @@
+var hasProp = function (obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop)
+}
+
 exports.extend = function (target, source) {
   // Shallow object extend.
   // Return a new object where keys and values of the source
@@ -6,12 +10,12 @@ exports.extend = function (target, source) {
   var k
   var obj = {}
   for (k in target) {
-    if (Object.prototype.hasOwnProperty.call(target, k)) {
+    if (hasProp(target, k)) {
       obj[k] = target[k]
     }
   }
   for (k in source) {
-    if (Object.prototype.hasOwnProperty.call(source, k)) {
+    if (hasProp(source, k)) {
       obj[k] = source[k]
     }
   }
@@ -40,7 +44,7 @@ exports.clone = function (obj) {
   var res = {}
 
   for (k in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, k)) {
+    if (hasProp(obj, k)) {
       res[k] = obj[k]
     }
   }
@@ -54,7 +58,7 @@ exports.cardinality = function (obj) {
   var res = 0
 
   for (k in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, k)) {
+    if (hasProp(obj, k)) {
       res += 1
     }
   }

--- a/lib/Touchable/utils.js
+++ b/lib/Touchable/utils.js
@@ -1,4 +1,3 @@
-
 exports.extend = function (target, source) {
   // Shallow object extend.
   // Return a new object where keys and values of the source
@@ -7,12 +6,12 @@ exports.extend = function (target, source) {
   var k
   var obj = {}
   for (k in target) {
-    if (target.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(target, k)) {
       obj[k] = target[k]
     }
   }
   for (k in source) {
-    if (source.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(source, k)) {
       obj[k] = source[k]
     }
   }
@@ -41,7 +40,7 @@ exports.clone = function (obj) {
   var res = {}
 
   for (k in obj) {
-    if (obj.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(obj, k)) {
       res[k] = obj[k]
     }
   }
@@ -55,7 +54,7 @@ exports.cardinality = function (obj) {
   var res = 0
 
   for (k in obj) {
-    if (obj.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(obj, k)) {
       res += 1
     }
   }

--- a/lib/geom/Grid.js
+++ b/lib/geom/Grid.js
@@ -37,7 +37,7 @@ var snap = function (x, step, phase) {
   // Return
   //   number
   //
-  return (Math.round((x - phase) / step) * step) + phase
+  return Math.round((x - phase) / step) * step + phase
 }
 
 var Grid = function (stepMode) {
@@ -47,10 +47,14 @@ var Grid = function (stepMode) {
     stepMode = extend({}, DEFAULT_STEPMODE, stepMode)
   }
 
-  if ((stepMode.xStep < EPSILON && stepMode.yStep > EPSILON) ||
-      (stepMode.xStep > EPSILON && stepMode.yStep < EPSILON)) {
-    throw new Error('Grid xStep and yStep must be either both zero or ' +
-      'both greater than zero.')
+  if (
+    (stepMode.xStep < EPSILON && stepMode.yStep > EPSILON) ||
+    (stepMode.xStep > EPSILON && stepMode.yStep < EPSILON)
+  ) {
+    throw new Error(
+      'Grid xStep and yStep must be either both zero or ' +
+        'both greater than zero.'
+    )
     // because otherwise handling with grid basis vectors becomes
     // unnecessarily complicated.
   }
@@ -75,8 +79,8 @@ proto.almostEqual = function (grid) {
   var gm = grid.mode
 
   for (k in tm) {
-    if (tm.hasOwnProperty(k)) {
-      if (gm.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(tm, k)) {
+      if (Object.prototype.hasOwnProperty.call(gm, k)) {
         if (Math.abs(tm[k] - gm[k]) > EPSILON) {
           return false
         }
@@ -116,8 +120,7 @@ proto.at = function (i, j) {
   return origin.add(gbx.multiply(i)).add(gby.multiply(j))
 }
 
-proto.equal =
-proto.equals = function (grid) {
+proto.equal = proto.equals = function (grid) {
   // Return bool. True if modes of the grids equal.
   //
   var k
@@ -125,8 +128,8 @@ proto.equals = function (grid) {
   var gm = grid.mode
 
   for (k in tm) {
-    if (tm.hasOwnProperty(k)) {
-      if (gm.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(tm, k)) {
+      if (Object.prototype.hasOwnProperty.call(gm, k)) {
         if (tm[k] !== gm[k]) {
           return false
         }
@@ -174,7 +177,7 @@ proto.getHullOf = function (i, j) {
   var c3 = vor.add(gbx.multiply(i + 1)).add(gby.multiply(j))
 
   // Call getHull to ensure correct order.
-  return (new Path([c0, c1, c2, c3])).getHull()
+  return new Path([c0, c1, c2, c3]).getHull()
 }
 
 proto.getOrigin = function () {

--- a/lib/geom/Grid.js
+++ b/lib/geom/Grid.js
@@ -22,6 +22,10 @@ var DEFAULT_STEPMODE = {
   yRotation: Math.PI / 2
 }
 
+var hasProp = function (obj, prop) {
+  return obj && Object.prototype.hasOwnProperty.call(obj, prop)
+}
+
 var snap = function (x, step, phase) {
   // Find x' in { i * step + phase | i in N }
   // such that abs(x - x') is minimal. N is the set of integers.
@@ -79,8 +83,8 @@ proto.almostEqual = function (grid) {
   var gm = grid.mode
 
   for (k in tm) {
-    if (Object.prototype.hasOwnProperty.call(tm, k)) {
-      if (Object.prototype.hasOwnProperty.call(gm, k)) {
+    if (hasProp(tm, k)) {
+      if (hasProp(gm, k)) {
         if (Math.abs(tm[k] - gm[k]) > EPSILON) {
           return false
         }
@@ -128,8 +132,8 @@ proto.equal = proto.equals = function (grid) {
   var gm = grid.mode
 
   for (k in tm) {
-    if (Object.prototype.hasOwnProperty.call(tm, k)) {
-      if (Object.prototype.hasOwnProperty.call(gm, k)) {
+    if (hasProp(tm, k)) {
+      if (hasProp(gm, k)) {
         if (tm[k] !== gm[k]) {
           return false
         }

--- a/lib/geom/IGrid.js
+++ b/lib/geom/IGrid.js
@@ -20,7 +20,7 @@ var IGrid = function (grid, plane) {
   if (typeof grid === 'undefined') {
     this._grid = new Grid()
   } else {
-    if (!grid.hasOwnProperty('mode')) {
+    if (!Object.prototype.hasOwnProperty.call(grid, 'mode')) {
       // Step mode given
       grid = new Grid(grid)
     }
@@ -43,8 +43,7 @@ proto.at = function (x, y) {
   return new IVector(this._grid.at(x, y))
 }
 
-proto.equal =
-proto.equals = function (igrid) {
+proto.equal = proto.equals = function (igrid) {
   // Return true if grids match.
   return this._grid.equals(igrid._grid)
 }

--- a/lib/geom/ITransform.js
+++ b/lib/geom/ITransform.js
@@ -66,12 +66,14 @@ var ITransform = function (transf, plane) {
   if (plane && !('_T' in plane)) {
     throw new Error('invalid reference')
   }
-  if (transf && !transf.hasOwnProperty('tx')) {
+  if (transf && !Object.prototype.hasOwnProperty.call(transf, 'tx')) {
     throw new Error('invalid transform')
   }
 
   // transf is the transformation on the plane.
-  if (typeof transf === 'undefined') { transf = Transform.IDENTITY }
+  if (typeof transf === 'undefined') {
+    transf = Transform.IDENTITY
+  }
 
   if (plane) {
     // Convert transformation to space
@@ -84,14 +86,12 @@ var ITransform = function (transf, plane) {
 
 var proto = ITransform.prototype
 
-proto.almostEqual =
-proto.almostEquals = function (gt) {
+proto.almostEqual = proto.almostEquals = function (gt) {
   // See Transform.almostEqual
   return this._tr.almostEqual(gt._tr)
 }
 
-proto.equal =
-proto.equals = function (gt) {
+proto.equal = proto.equals = function (gt) {
   // Test if given ITransform represents equivalent transformation
   // regardless of reference.
   //
@@ -134,9 +134,7 @@ proto.toSpace = function () {
   return this._tr
 }
 
-proto.multiplyRight =
-proto.multiplyBy =
-proto.transformBy = function (itr) {
+proto.multiplyRight = proto.multiplyBy = proto.transformBy = function (itr) {
   // Transform the image of this by given ITransform.
   //
   // Parameters:
@@ -186,7 +184,7 @@ proto.scale = function (pivot, multiplierOrDomain, range) {
   //   range: array of IVector
   var useMultiplier, normPivot, domain, multiplier, tr, itr
 
-  useMultiplier = (typeof range === 'undefined')
+  useMultiplier = typeof range === 'undefined'
 
   if (useMultiplier) {
     normPivot = pivot.toSpace().toArray()
@@ -211,7 +209,7 @@ proto.rotate = function (pivot, radiansOrDomain, range) {
   //   range: array of IVector
   var useRadians, normPivot, domain, radians, tr, itr
 
-  useRadians = (typeof range === 'undefined')
+  useRadians = typeof range === 'undefined'
 
   if (useRadians) {
     normPivot = pivot.toSpace().toArray()
@@ -283,15 +281,15 @@ ITransform.estimate = function (type, domain, range, pivot) {
   }
 
   // Allow singles & IPaths
-  if (domain.hasOwnProperty('_vec')) {
+  if (Object.prototype.hasOwnProperty.call(domain, '_vec')) {
     domain = [domain]
-  } else if (domain.hasOwnProperty('_p')) {
+  } else if (Object.prototype.hasOwnProperty.call(domain, '_p')) {
     domain = domain.toArray()
   }
 
-  if (range.hasOwnProperty('_vec')) {
+  if (Object.prototype.hasOwnProperty.call(range, '_vec')) {
     range = [range]
-  } else if (range.hasOwnProperty('_p')) {
+  } else if (Object.prototype.hasOwnProperty.call(range, '_p')) {
     range = range.toArray()
   }
 

--- a/lib/geom/ITransform.js
+++ b/lib/geom/ITransform.js
@@ -12,6 +12,10 @@ Thus, most exact name would be a coordinate-plane-invariant transformation.
 var Transform = require('./Transform')
 var nudged = require('nudged')
 
+var hasProp = function (obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop)
+}
+
 // NOT YET USED ANYWHERE
 // var getTrBetweenPlanes = function (sourcePlane, targetPlane) {
 //   // Return a Transform that represents a mapping from sourcePlane
@@ -66,7 +70,7 @@ var ITransform = function (transf, plane) {
   if (plane && !('_T' in plane)) {
     throw new Error('invalid reference')
   }
-  if (transf && !Object.prototype.hasOwnProperty.call(transf, 'tx')) {
+  if (transf && !hasProp(transf, 'tx')) {
     throw new Error('invalid transform')
   }
 
@@ -281,15 +285,15 @@ ITransform.estimate = function (type, domain, range, pivot) {
   }
 
   // Allow singles & IPaths
-  if (Object.prototype.hasOwnProperty.call(domain, '_vec')) {
+  if (hasProp(domain, '_vec')) {
     domain = [domain]
-  } else if (Object.prototype.hasOwnProperty.call(domain, '_p')) {
+  } else if (hasProp(domain, '_p')) {
     domain = domain.toArray()
   }
 
-  if (Object.prototype.hasOwnProperty.call(range, '_vec')) {
+  if (hasProp(range, '_vec')) {
     range = [range]
-  } else if (Object.prototype.hasOwnProperty.call(range, '_p')) {
+  } else if (hasProp(range, '_p')) {
     range = range.toArray()
   }
 

--- a/lib/geom/Path.js
+++ b/lib/geom/Path.js
@@ -24,10 +24,10 @@ proto.add = function (p) {
   // Return
   //   new Path
 
-  if (p.hasOwnProperty('_seg')) {
+  if (Object.prototype.hasOwnProperty.call(p, '_seg')) {
     // Path
     return new Path(this._seg.concat(p._seg))
-  } else if (p.hasOwnProperty('x')) {
+  } else if (Object.prototype.hasOwnProperty.call(p, 'x')) {
     // Vector
     return new Path(this._seg.concat([p]))
   }
@@ -76,7 +76,7 @@ proto.atMid = function () {
   }
 
   for (i = 0; i + 1 < s.length; i += 1) {
-    d = (s[i].x * s[i + 1].y) - (s[i + 1].x * s[i].y)
+    d = s[i].x * s[i + 1].y - s[i + 1].x * s[i].y
     cx += (s[i].x + s[i + 1].x) * d
     cy += (s[i].y + s[i + 1].y) * d
     area += d
@@ -84,7 +84,7 @@ proto.atMid = function () {
 
   // Close the path
   // i + 1 === s.length
-  d = (s[i].x * s[0].y - s[0].x * s[i].y)
+  d = s[i].x * s[0].y - s[0].x * s[i].y
   cx += (s[i].x + s[0].x) * d
   cy += (s[i].y + s[0].y) * d
   area += d
@@ -127,8 +127,7 @@ proto.bottom = function () {
   return maxv
 }
 
-proto.equal =
-proto.equals = function (p) {
+proto.equal = proto.equals = function (p) {
   // Test if two paths are equal
   if (this._seg.length === p._seg.length) {
     for (var i = 0; i < this._seg.length; i += 1) {
@@ -199,9 +198,11 @@ proto.getHull = function () {
     return this
   }
 
-  var indices = convexHull(this._seg.map(function (vec) {
-    return vec.toArray()
-  }))
+  var indices = convexHull(
+    this._seg.map(function (vec) {
+      return vec.toArray()
+    })
+  )
 
   // The convexHull returns the points in clockwise order
   // but assumes positive y to head up. In web browsers,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,7 +31,7 @@ var UNITS = {
 }
 
 for (var unit in UNITS) {
-  if (UNITS.hasOwnProperty(unit)) {
+  if (Object.prototype.hasOwnProperty.call(UNITS, unit)) {
     UNITS[unit](harness(unit))
   }
 }

--- a/test/item.test/AbstractRectangle.test.js
+++ b/test/item.test/AbstractRectangle.test.js
@@ -20,7 +20,11 @@ module.exports = function (test) {
     var space = new Space()
     var a = new SpacePixel('black', space)
     a.remove()
-    t.equal(space._children.hasOwnProperty(a.id), false, 'removed ok')
+    t.equal(
+      Object.prototype.hasOwnProperty.call(space._children, a.id),
+      false,
+      'removed ok'
+    )
     t.end()
   })
 

--- a/test/webpack.browser.config.js
+++ b/test/webpack.browser.config.js
@@ -3,7 +3,7 @@ var path = require('path')
 
 module.exports = {
   entry: {
-    'index': './index.test.js'
+    index: './index.test.js'
   },
   context: __dirname,
 

--- a/test/webpack.headless.config.js
+++ b/test/webpack.headless.config.js
@@ -3,7 +3,7 @@ var path = require('path')
 
 module.exports = {
   entry: {
-    'index': './index.test.js'
+    index: './index.test.js'
   },
   context: __dirname,
 


### PR DESCRIPTION
Fixes to make npm run lint work again.

Specifically all calls to the method hasOwnProperty have been changed to calls to Object.prototype.hasOwnProperty.

Tests appear to all still pass.